### PR TITLE
Improve Slurm script

### DIFF
--- a/training/bing_bert/INSTALL.md
+++ b/training/bing_bert/INSTALL.md
@@ -15,11 +15,10 @@ pip install tensorboardX boto3 requests h5py
 
 cd ../DeepSpeedExamples/training/bing_bert
 
-# download dataset from https://cloudstore.zih.tu-dresden.de/index.php/s/RyeDoaogesGJFCR 
-# change dataset path in ds_train_bert_nvidia_data_bsz64k_seq128_slurm.sh
-# change bert_token_file bert_model_file which included into the dataset
+# download & extract dataset from https://cloudstore.zih.tu-dresden.de/index.php/s/RyeDoaogesGJFCR
+# change dataset path in ds_train_bert_nvidia_data_bsz64k_seq128_tud.sh
 # change train_micro_batch_size_per_gpu in deepspeed_bsz64k_lamb_config_seq128_tud.json to gpu memory
 
-srun ./ds_train_bert_nvidia_data_bsz64k_seq128_slurm.sh
+srun ./ds_train_bert_nvidia_data_bsz64k_seq128_tud.sh
 
 ```

--- a/training/bing_bert/ds_train_bert_nvidia_data_bsz64k_seq128_slurm.sh
+++ b/training/bing_bert/ds_train_bert_nvidia_data_bsz64k_seq128_slurm.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-base_dir=`pwd`
+base_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Where should we save checkpoints and tensorboard events?
 JOB_NAME=lamb_nvidia_data_64k_seq128
-OUTPUT_DIR=${base_dir}/bert_model_nvidia_data_outputs
+OUTPUT_DIR=$(pwd)/bert_model_nvidia_data_outputs
 
 DATA_PATH="/workspace/bert"
 
@@ -18,18 +18,18 @@ master_addr=$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n 1)
 export MASTER_ADDR=$master_addr
 
 
-mkdir -p $OUTPUT_DIR
+mkdir -p "$OUTPUT_DIR"
 
-NCCL_TREE_THRESHOLD=0 python ${base_dir}/deepspeed_train.py \
---cf ${base_dir}/bert_large_lamb_nvidia_data.json \
+NCCL_TREE_THRESHOLD=0 python "${base_dir}/deepspeed_train.py" \
+--cf "${base_dir}/bert_large_lamb_nvidia_data.json" \
 --max_seq_length 128 \
---output_dir $OUTPUT_DIR \
+--output_dir "$OUTPUT_DIR" \
 --deepspeed \
 --deepspeed_transformer_kernel \
 --print_steps 100 \
 --lr_schedule "EE" \
 --lr_offset 10e-4 \
---job_name $JOB_NAME \
---deepspeed_config ${base_dir}/deepspeed_bsz64k_lamb_config_seq128.json \
---data_path_prefix $DATA_PATH \
+--job_name "$JOB_NAME" \
+--deepspeed_config "${base_dir}/deepspeed_bsz64k_lamb_config_seq128.json" \
+--data_path_prefix "$DATA_PATH" \
 --use_nvidia_dataset 

--- a/training/bing_bert/ds_train_bert_nvidia_data_bsz64k_seq128_tud.sh
+++ b/training/bing_bert/ds_train_bert_nvidia_data_bsz64k_seq128_tud.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+base_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Where should we save checkpoints and tensorboard events?
+JOB_NAME=lamb_nvidia_data_64k_seq128
+OUTPUT_DIR=$(pwd)/bert_model_nvidia_data_outputs
+
+DATA_PATH="/workspace/bert/dataset"
+
+
+export RANK=$SLURM_PROCID
+export LOCAL_RANK=$SLURM_LOCALID
+export WORLD_SIZE=$SLURM_NTASKS
+
+export MASTER_PORT=$(expr 10000 + $(echo -n $SLURM_JOBID | tail -c 4))
+master_addr=$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n 1)
+export MASTER_ADDR=$master_addr
+
+
+mkdir -p "$OUTPUT_DIR"
+
+# bert_large_lamb_nvidia_data_tud.json expects token/model file in specific subfolder of the current dir
+if [[ $(basename "$DATA_PATH") != "dataset" ]]; then
+  echo "\$DATA_PATH must point to the 'dataset' folder!" >&2
+  exit 1
+fi
+cd "$(dirname "$DATA_PATH")"
+
+NCCL_TREE_THRESHOLD=0 python "${base_dir}/deepspeed_train.py" \
+--cf "${base_dir}/bert_large_lamb_nvidia_data_tud.json" \
+--max_seq_length 128 \
+--output_dir "$OUTPUT_DIR" \
+--deepspeed \
+--deepspeed_transformer_kernel \
+--print_steps 100 \
+--lr_schedule "EE" \
+--lr_offset 10e-4 \
+--job_name "$JOB_NAME" \
+--deepspeed_config "${base_dir}/deepspeed_bsz64k_lamb_config_seq128_tud.json" \
+--data_path_prefix "$DATA_PATH" \
+--use_nvidia_dataset 


### PR DESCRIPTION
The instructions in the `INSTALL.md` file were not working:

- It refers to changes to `deepspeed_bsz64k_lamb_config_seq128_tud.json` but `deepspeed_bsz64k_lamb_config_seq128.json` is used
- `bert_large_lamb_nvidia_data.json` used in the slurm script doesn't use the dataset, `bert_large_lamb_nvidia_data_tud.json` was intended(?)
- `bert_large_lamb_nvidia_data_tud.json` uses `"bert_token_file": "dataset/vocab.txt"` i.e. a relative path. The instructions that those would need to be replaced by absolute paths were not fully clear, so it is easier to skip that step and ensure that relative path works

To keep the original setup, which may be useful, I created a copy using the `*_tud.json` configs and corresponding `.sh` script.