### PR TITLE
Improve export_from_tensorboard.py

### DIFF
--- a/training/bing_bert/export_from_tensorboard.py
+++ b/training/bing_bert/export_from_tensorboard.py
@@ -1,38 +1,33 @@
+#!/usr/bin/env python3
+
 from tbparse import SummaryReader
 import pandas as pd
 import argparse
 
 
-
 def parse_tb2(logdir, csv_out):
-	reader = SummaryReader(logdir, extra_columns=set(['wall_time']))
-	df = reader.scalars
+    reader = SummaryReader(logdir, extra_columns=set(['wall_time']))
+    df = reader.scalars
 
-	df['wall_clock'] = pd.to_datetime(df.wall_time, unit="s")
-	first = df.wall_time[0]
-	df['Runtime'] = df.wall_time - first
-	
-	loss_df = df[df['tag'] == 'Train/Samples/train_loss'].copy()
-	loss_df.rename(columns = {'step' : 'Samples', 'value' : 'Loss'}, inplace=True)
-	loss_df.drop(columns = ['tag', 'wall_time', 'wall_clock'], inplace=True)
-	
-	
-	if csv_out:
-#		df[df['tag'] == 'Train/Samples/train_loss'].to_csv(csv_out)
-		loss_df.to_csv(csv_out)
-	
-	return loss_df
+    loss_df = df[df['tag'] == 'Train/Samples/train_loss'].reset_index(drop=True)
 
-	
-	
-	
-	
+    loss_df['wall_clock'] = pd.to_datetime(loss_df.wall_time, unit="s")
+    first = loss_df.wall_time.iloc[0]
+    loss_df['Runtime (sec)'] = loss_df.wall_time - first
+
+    loss_df.rename(columns={'step': 'Samples', 'value': 'Loss'}, inplace=True)
+    loss_df.drop(columns=['tag', 'wall_time', 'wall_clock'], inplace=True)
+
+    if csv_out:
+        loss_df.to_csv(csv_out)
+
+    return loss_df
 
 
 if __name__ == '__main__':
-	parser = argparse.ArgumentParser(description='Parse TensorBoard Event files and prints them')
-	parser.add_argument('logdir', help='TensorBoard logdir')
-	parser.add_argument('--csv_out', help='csv output file', required=False, default=None)
-	args = parser.parse_args()
+    parser = argparse.ArgumentParser(description='Parse & print TensorBoard event files')
+    parser.add_argument('logdir', help='TensorBoard logdir')
+    parser.add_argument('--csv_out', help='csv output file')
+    args = parser.parse_args()
 
-	print(parse_tb2(args.logdir, args.csv_out))
+    print(parse_tb2(args.logdir, args.csv_out))


### PR DESCRIPTION
- Spaces instead of TABs (as per PEP8)
- Remove superflous arguments
- Reindex dataset after dropping rows
- Use first time in `train_loss` dataset as start time to avoid negative times
- Rename "Runtime"->"Runtime (sec)"
- Make script executable

Prior output:
```
   Samples       Loss      Runtime
4    65536  11.195312    -0.000362
5   131072  11.937500   648.497936
6   196608  10.953125  1252.262939
7   262144  10.218750  1855.988765
```

New output:
```
   Samples       Loss  Runtime (sec)
0    65536  11.195312       0.000000
1   131072  11.937500     648.498298
2   196608  10.953125    1252.263301
3   262144  10.218750    1855.989127
```
