### PR TITLE
Add mpi4py to required packages

### DIFF
--- a/training/bing_bert/INSTALL.md
+++ b/training/bing_bert/INSTALL.md
@@ -11,8 +11,8 @@ git clone --branch=gpu_bench https://github.com/tud-zih-ki/DeepSpeedExamples.git
 cd DeepSpeed
 pip install .
 
-pip install tensorboardX boto3 requests h5py 
-pip install tbparse # required in export_from_tensorboard.py 
+pip install tensorboardX boto3 requests h5py mpi4py
+pip install tbparse # required in export_from_tensorboard.py
 
 cd ../DeepSpeedExamples/training/bing_bert
 


### PR DESCRIPTION
https://github.com/tud-zih-ki/DeepSpeedExamples/blob/gpu_bench/benchmarks/communication/INSTALL.md refers to this environment yet it launches `all_reduce.py` directly via `srun`.

Hence the communication variables (`$RANK`, `$WORLD_SIZE`, ...) set in e.g. `ds_train_bert_nvidia_data_bsz64k_seq128_slurm.sh` are not set.

DeepSpeed can use MPI to auto-discover those making it much simpler to start DeepSpeed applications.   
This is what happens in `deepspeed.init_distributed` called by `all_reduce.py` (through `init_processes`) in the above scenario but it fails in a "clean" environment prepared via `training/bing_bert/INSTALL.md` as the mpi4py package is missing.

I added it to this INSTALL.md as it may be useful for other use cases too, e.g. starting `deepspeed_train.py` directly via `srun`