### PR TITLE
Calculate and display time to reach target loss

### DIFF
--- a/training/bing_bert/export_from_tensorboard.py
+++ b/training/bing_bert/export_from_tensorboard.py
@@ -1,38 +1,33 @@
+#!/usr/bin/env python3
+
 from tbparse import SummaryReader
 import pandas as pd
 import argparse
 
 
-
 def parse_tb2(logdir, csv_out):
-	reader = SummaryReader(logdir, extra_columns=set(['wall_time']))
-	df = reader.scalars
+    reader = SummaryReader(logdir, extra_columns=set(['wall_time']))
+    df = reader.scalars
 
-	df['wall_clock'] = pd.to_datetime(df.wall_time, unit="s")
-	first = df.wall_time[0]
-	df['Runtime'] = df.wall_time - first
-	
-	loss_df = df[df['tag'] == 'Train/Samples/train_loss'].copy()
-	loss_df.rename(columns = {'step' : 'Samples', 'value' : 'Loss'}, inplace=True)
-	loss_df.drop(columns = ['tag', 'wall_time', 'wall_clock'], inplace=True)
-	
-	
-	if csv_out:
-#		df[df['tag'] == 'Train/Samples/train_loss'].to_csv(csv_out)
-		loss_df.to_csv(csv_out)
-	
-	return loss_df
+    loss_df = df[df['tag'] == 'Train/Samples/train_loss'].reset_index(drop=True)
 
-	
-	
-	
-	
+    loss_df['wall_clock'] = pd.to_datetime(loss_df.wall_time, unit="s")
+    first = loss_df.wall_time.iloc[0]
+    loss_df['Runtime (sec)'] = loss_df.wall_time - first
+
+    loss_df.rename(columns={'step': 'Samples', 'value': 'Loss'}, inplace=True)
+    loss_df.drop(columns=['tag', 'wall_time', 'wall_clock'], inplace=True)
+
+    if csv_out:
+        loss_df.to_csv(csv_out)
+
+    return loss_df
 
 
 if __name__ == '__main__':
-	parser = argparse.ArgumentParser(description='Parse TensorBoard Event files and prints them')
-	parser.add_argument('logdir', help='TensorBoard logdir')
-	parser.add_argument('--csv_out', help='csv output file', required=False, default=None)
-	args = parser.parse_args()
+    parser = argparse.ArgumentParser(description='Parse & print TensorBoard event files')
+    parser.add_argument('logdir', help='TensorBoard logdir')
+    parser.add_argument('--csv_out', help='csv output file')
+    args = parser.parse_args()
 
-	print(parse_tb2(args.logdir, args.csv_out))
+    print(parse_tb2(args.logdir, args.csv_out))

--- a/training/bing_bert/export_from_tensorboard.py
+++ b/training/bing_bert/export_from_tensorboard.py
@@ -4,6 +4,7 @@ from tbparse import SummaryReader
 import pandas as pd
 import argparse
 
+RUNTIME_NAME = 'Runtime (sec)'
 
 def parse_tb2(logdir, csv_out):
     reader = SummaryReader(logdir, extra_columns=set(['wall_time']))
@@ -13,7 +14,7 @@ def parse_tb2(logdir, csv_out):
 
     loss_df['wall_clock'] = pd.to_datetime(loss_df.wall_time, unit="s")
     first = loss_df.wall_time.iloc[0]
-    loss_df['Runtime (sec)'] = loss_df.wall_time - first
+    loss_df[RUNTIME_NAME] = loss_df.wall_time - first
 
     loss_df.rename(columns={'step': 'Samples', 'value': 'Loss'}, inplace=True)
     loss_df.drop(columns=['tag', 'wall_time', 'wall_clock'], inplace=True)
@@ -24,10 +25,23 @@ def parse_tb2(logdir, csv_out):
     return loss_df
 
 
+def find_runtime(df, min_iters, loss_limit):
+    for d in df.rolling(min_iters, method="table"):
+        if d.shape[0] == min_iters and (d['Loss'] < loss_limit).all():
+            return d.iloc[-1][RUNTIME_NAME]
+
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Parse & print TensorBoard event files')
     parser.add_argument('logdir', help='TensorBoard logdir')
     parser.add_argument('--csv_out', help='csv output file')
     args = parser.parse_args()
 
-    print(parse_tb2(args.logdir, args.csv_out))
+    data = parse_tb2(args.logdir, args.csv_out)
+    print(data)
+    print('='*60)
+    target_runtime = find_runtime(data, min_iters=2, loss_limit=8.5)
+    if target_runtime:
+        print(f"Time to reach target loss: {target_runtime:.2f} s")
+    else:
+        print("Target loss not reached")

--- a/training/bing_bert/export_from_tensorboard.py
+++ b/training/bing_bert/export_from_tensorboard.py
@@ -35,12 +35,14 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Parse & print TensorBoard event files')
     parser.add_argument('logdir', help='TensorBoard logdir')
     parser.add_argument('--csv_out', help='csv output file')
+    parser.add_argument('--threshold', help='Loss value that should be undercut', type=float, default=8.5)
+    parser.add_argument('--min_iters', help='Number of iterations the threshold should be reached', type=int, default=2)
     args = parser.parse_args()
 
     data = parse_tb2(args.logdir, args.csv_out)
     print(data)
     print('='*60)
-    target_runtime = find_runtime(data, min_iters=2, loss_limit=8.5)
+    target_runtime = find_runtime(data, min_iters=args.min_iters, loss_limit=args.threshold)
     if target_runtime:
         print(f"Time to reach target loss: {target_runtime:.2f} s")
     else:


### PR DESCRIPTION
Based on #2

Add a function to find the time when the loss dropped below a threshold for a minimum number of iterations and print that value rounded to 2 decimals.

Example output (target loss set to 11.0 for testing):
```
   Samples       Loss  Runtime (sec)
0    65536  11.195312       0.000000
1   131072  11.937500     648.498298
2   196608  10.953125    1252.263301
3   262144  10.218750    1855.989127
============================================================
Time to reach target loss: 1855.99 s
```
